### PR TITLE
Tentative to fix failing builds by updating Node.js to LTS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,6 @@ inputs:
     default: 'true'
 
 runs:
-  using: 'node12'
+  using: 'node14'
   main: 'dist/setup/index.js'
   post: 'dist/cleanup/index.js'


### PR DESCRIPTION
no idea what I'm doing, but seeing the output of vault-cli-setup on https://github.com/LedgerHQ/minivault/runs/3585014807?check_suite_focus=true, could be worth trying